### PR TITLE
accessibility_improvements

### DIFF
--- a/commendations.html
+++ b/commendations.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en" dir="ltr">
 <head>
-  <title>Commendations | Sabbadino Driver Training</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="title" content="Upstate Driver Education Courses, Sabbadino Driving School, Taylors Driving Lessons" />
   <meta name="description" content="Read about the awards and honors Mr. Sabbadino has earned during his teaching career." />
   <meta name="keyword" content="driver education, driving school, defensive driving, traffic education, upstate driving courses" />
+  <title>Commendations | Sabbadino Driver Training</title>
   <link href="reset.css" rel="stylesheet" type="text/css" />
   <link href="bootstrap.min.css" rel="stylesheet" type="text/css" />
   <link href="styles.css" rel="stylesheet" type="text/css" />

--- a/credentials.html
+++ b/credentials.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en" dir="ltr">
 <head>
-  <title>Credentials | Sabbadino Driver Training</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="title" content="Upstate Driver Education Courses, Sabbadino Driving School, Taylors Driving Lessons" />
   <meta name="description" content="Read about Mr. Sabbadino's education and experience in the driver training field." />
   <meta name="keyword" content="driver education, driving school, defensive driving, traffic education, upstate driving courses" />
+  <title>Credentials | Sabbadino Driver Training</title>
   <link href="reset.css" rel="stylesheet" type="text/css" />
   <link href="bootstrap.min.css" rel="stylesheet" type="text/css" />
   <link href="styles.css" rel="stylesheet" type="text/css" />

--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en" dir="ltr">
 <head>
-  <title>Sabbadino Driver Training &mdash; Greenville, SC Driver Education Courses</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="title" content="Upstate Driver Education Courses, Sabbadino Driving School, Taylors Driving Lessons" />
   <meta name="description" content="Learn to drive near Greenville SC from one of the leading driving instructors in the Upstate." />
   <meta name="keyword" content="driver education, driving school, defensive driving, traffic education, upstate driving courses" />
+  <title>Sabbadino Driver Training &mdash; Greenville, SC Driver Education Courses</title>
   <link href="reset.css" rel="stylesheet" type="text/css" />
   <link href="bootstrap.min.css" rel="stylesheet" type="text/css" />
   <link href="styles.css" rel="stylesheet" type="text/css" />

--- a/pictures.html
+++ b/pictures.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en" dir="ltr">
 <head>
-  <title>Media | Sabbadino Driver Training</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="title" content="Upstate Driver Education Courses, Sabbadino Driving School, Taylors Driving Lessons" />
   <meta name="description" content="What does driver training look like? Check out these pictures taken during both our classroom and behind-the-wheel training." />
   <meta name="keyword" content="driver education, driving school, defensive driving, traffic education, upstate driving courses" />
+  <title>Media | Sabbadino Driver Training</title>
   <link href="reset.css" rel="stylesheet" type="text/css" />
   <link href="bootstrap.min.css" rel="stylesheet" type="text/css" />
   <link href="styles.css" rel="stylesheet" type="text/css" />

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,14 @@ li {
   line-height: 1.3em;
 }
 
+a {
+  color: #0044dd;
+}
+
+a:hover {
+  color: #0000aa;
+}
+
 @media screen and (min-width: 800px) {
   .two-columns {
     -webkit-columns: 2;

--- a/teaching.html
+++ b/teaching.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en" dir="ltr">
 <head>
-  <title>Teaching Philosophy | Sabbadino Driver Training</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="title" content="Upstate Driver Education Courses, Sabbadino Driving School, Taylors Driving Lessons" />
   <meta name="description" content="Learn about Mr. Sabbadino's teaching philosophy that drives his excellent driver training courses." />
   <meta name="keyword" content="driver education, driving school, defensive driving, traffic education, upstate driving courses" />
+  <title>Teaching Philosophy | Sabbadino Driver Training</title>
   <link href="reset.css" rel="stylesheet" type="text/css" />
   <link href="bootstrap.min.css" rel="stylesheet" type="text/css" />
   <link href="styles.css" rel="stylesheet" type="text/css" />

--- a/testimonials.html
+++ b/testimonials.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en" dir="ltr">
 <head>
-  <title>Testimonials | Sabbadino Driver Training</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="title" content="Upstate Driver Education Courses, Sabbadino Driving School, Taylors Driving Lessons" />
   <meta name="description" content="Read what former students and parents have said about the quality of Mr. Sabbadino's driver training course." />
   <meta name="keyword" content="driver education, driving school, defensive driving, traffic education, upstate driving courses" />
+  <title>Testimonials | Sabbadino Driver Training</title>
   <link href="reset.css" rel="stylesheet" type="text/css" />
   <link href="bootstrap.min.css" rel="stylesheet" type="text/css" />
   <link href="styles.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
According to https://htmlhead.dev/, the `<meta charset />` and `<meta name="viewport" />` tags should be the first ones in the `<head>` element. I implemented that on all pages of this site, and I changed the color of links within content to pass WCAG AAA standards.